### PR TITLE
Feature/delegate payment subscriptions

### DIFF
--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -230,21 +230,22 @@ def start_tasks(automatic_tasks):
     scheduler = AsyncIOScheduler()
     print('Started Chron Monitors')
 
-    # scheduler.add_job(automatic_tasks.delegate_daily_snapshot,
-    #                   CronTrigger(hour='23', minute='59', second='59'), misfire_grace_time=2, max_instances=20)
-    # scheduler.add_job(automatic_tasks.delegate_hourly_snapshots,
-    #                   CronTrigger(minute='00'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_daily_snapshot,
+                      CronTrigger(hour='23', minute='59', second='59'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_hourly_snapshots,
+                      CronTrigger(minute='00', second='00'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.system_payment_notifications,
-                      CronTrigger(second='00'), misfire_grace_time=2, max_instances=20)
-    scheduler.add_job(automatic_tasks.send_payment_dms,
                       CronTrigger(second='05'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.send_payment_dms,
+                      CronTrigger(second='10'), misfire_grace_time=2, max_instances=20)
     #
     # scheduler.add_job(automatic_tasks.delegate_ranks, CronTrigger(hour='02', second='02'), misfire_grace_time=2,
     #                   max_instances=20)
-    # scheduler.add_job(automatic_tasks.delegate_last_block_check,
-    #                   CronTrigger(minute='02,04,06,08,10,12,14,16,18,20,22,24,26,'
-    #                                      '28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58'), misfire_grace_time=2,
-    #                   max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_last_block_check,
+                      CronTrigger(minute='02,04,06,08,10,12,14,16,18,20,22,24,26,'
+                                         '28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58', second='15'),
+                      misfire_grace_time=2,
+                      max_instances=20)
 
     scheduler.start()
     print('Started Chron Monitors : DONE')

--- a/backendManager/integrityCheck.py
+++ b/backendManager/integrityCheck.py
@@ -3,7 +3,7 @@ class IntegrityCheck(object):
         self.connection = connection
         self.dpops_delegate = self.connection["DpopsDelegate"]  #
         self.required_collections = ["votersDb", "botSettings"]
-        self.required_documents = ["new_block", "delegate_daily" , "delegate_hourly"]
+        self.required_documents = ["new_block", "delegate_daily", "delegate_hourly", 'payment_notifications']
 
     def check_collections(self):
         """

--- a/backendManager/votersManager.py
+++ b/backendManager/votersManager.py
@@ -40,3 +40,8 @@ class VotersManager:
                                                    {"$set": {"paymentNotifications": int(status),
                                                              "lastProcessed": int(timestamp)}})
         return result.modified_count > 0
+
+    def payment_notifications_applied(self):
+        result = list(self.voters_collection.find({"paymentNotifications":{"$gt":0}}))
+
+        return result

--- a/backendManager/votersManager.py
+++ b/backendManager/votersManager.py
@@ -31,6 +31,12 @@ class VotersManager:
 
         return result.deleted_count > 0
 
-    def get_voter(self,user_id:int):
-        result = self.voters_collection.find_one({"userId":int(user_id)})
+    def get_voter(self, user_id: int):
+        result = self.voters_collection.find_one({"userId": int(user_id)})
         return result
+
+    def update_payment_notification_status(self, user_id: int, status: int, timestamp: int):
+        result = self.voters_collection.update_one({"userId": int(user_id)},
+                                                   {"$set": {"paymentNotifications": int(status),
+                                                             "lastProcessed": int(timestamp)}})
+        return result.modified_count > 0

--- a/xcash_wallet/xcash.py
+++ b/xcash_wallet/xcash.py
@@ -9,4 +9,4 @@ rpc_data = {
 
 class XcashManager:
     def __init__(self):
-        self.xcash_rpc = WalletRpc(rpc_data=rpc_data)
+        self.xcash_rpc_wallet = WalletRpc(rpc_data=rpc_data)

--- a/xcash_wallet/xcashRpcWallet.py
+++ b/xcash_wallet/xcashRpcWallet.py
@@ -38,12 +38,26 @@ class WalletRpc:
 
         return response.json()
 
+    def transfers(self):
+        rpc_input = {
+            'method': "get_transfers",
+            'params': {"out": True,
+                       "in":True
+                       }
+        }
+
+        rpc_input.update({"jsonrpc": "2.0", "id": "0"})
+
+        response = requests.post(self.json_rpc_url, data=json.dumps(rpc_input), headers=self.headers)
+
+        return response.json()
+
     def get_last_outgoing_transfers(self, last_processed_height):
         rpc_input = {
             'method': "get_transfers",
             'params': { "filter_by_height": True,
                         "out": True,
-                        "min_height": last_processed_height - 1
+                        "min_height": last_processed_height
                        }
         }
 

--- a/xcash_wallet/xcashRpcWallet.py
+++ b/xcash_wallet/xcashRpcWallet.py
@@ -38,6 +38,21 @@ class WalletRpc:
 
         return response.json()
 
+    def get_last_outgoing_transfers(self, last_processed_height):
+        rpc_input = {
+            'method': "get_transfers",
+            'params': { "filter_by_height": True,
+                        "out": True,
+                        "min_height": last_processed_height - 1
+                       }
+        }
+
+        rpc_input.update({"jsonrpc": "2.0", "id": "0"})
+
+        response = requests.post(self.json_rpc_url, data=json.dumps(rpc_input), headers=self.headers)
+
+        return response.json()
+
     def get_transfers_by_tx_id(self, tx_id:str):
         rpc_input = {
             'method': "get_transfer_by_txid",


### PR DESCRIPTION
- Delegate/server owner can apply for public notifications to channel when delegate sends out payments. Total amount in transaction with tx_id will be sent. 

- Users can apply for private notifications when delegate sends them payment. They will get information on transaction hash and transaction key, as well as time of payment and amount of XCASH received. 
