### PR TITLE
Feature/delegate stats live 

### DIFF
--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -40,38 +40,6 @@ class AutomaticTasks:
 
         await daily_stats.send(embed=delegate_daily)
 
-    async def send_dpops_stats(self):
-        try:
-            print('Getting global stats')
-            data = self.bot.dpops_queries.statistics.global_stats()
-            delegates_count = len(self.bot.dpops_queries.delegates.get_delegates())
-            data["totalDelegates"] = delegates_count
-            stats_chn = self.bot.get_channel(id=self.bot.stats_channel_id)
-            if not data.get("error"):
-                await global_stats(destination=stats_chn, data=data)
-            else:
-                error = data["error"]
-                print(error)
-        except Exception:
-            print("Error")
-
-    async def delegate_ranks(self):
-        all_delegates = self.bot.dpops_queries.delegates.get_delegates()
-        print("getting delegates")
-        if isinstance(all_delegates, list):
-            for delegate in all_delegates:
-                delegate["total_vote_count"] = int(delegate["total_vote_count"])
-
-            newlist = sorted(all_delegates, key=itemgetter('total_vote_count'), reverse=True)
-
-            top_10 = newlist[0:10]
-
-            stats_chn = self.bot.get_channel(id=self.bot.stats_channel_id)
-            await top_delegates(destination=stats_chn, c=Colour.dark_orange(), data=top_10)
-        else:
-            error = all_delegates["error"]
-            print(error)
-
     async def delegate_last_block_check(self):
         # Obtain settings and values from database as dict
         block_data = self.bot.setting.get_setting(setting_name='new_block')

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -158,7 +158,23 @@ class AutomaticTasks:
         else:
             print("Daily snapshots are not included")
 
-
+    async def delegate_6_h(self):
+        """
+        Send snapshot to channel every 6H
+        """
+        settings = self.bot.setting.get_setting(setting_name='delegate_6h')
+        if settings["status"] == 1:
+            delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
+            if not delegate_stats.get("error"):
+                if settings["status"] == 1:
+                    await self.delegate_overall_message(delegate_settings=settings,
+                                                        delegate_stats=delegate_stats,
+                                                        description='6 H Delegate Snapshot'
+                                                        )
+            else:
+                print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
+        else:
+            print("Daily snapshots are not included")
 
     async def delegate_12_h(self):
         """
@@ -291,6 +307,8 @@ def start_tasks(automatic_tasks):
                       CronTrigger(hour='00,03,06,09,12,15,18,21', second='2'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_4_h,
                       CronTrigger(hour='00,04,08,12,16,20', second='2'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_6_h,
+                      CronTrigger(hour='06,12,18', second='12'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_12_h,
                       CronTrigger(hour='00,12', second='10'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_daily_snapshot,

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -92,9 +92,9 @@ class AutomaticTasks:
         """
         Send daily snapshot of the delegate overall performance if activated
         """
-        delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
         daily_settings = self.bot.setting.get_setting(setting_name='delegate_daily')
         if daily_settings["status"] == 1:
+            delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
             if not delegate_stats.get("error"):
                 if daily_settings["status"] == 1:
                     await self.delegate_overall_message(delegate_settings=daily_settings, delegate_stats=delegate_stats,
@@ -108,9 +108,9 @@ class AutomaticTasks:
         """
         Send daily snapshot of the delegate overall performance if activated
         """
-        delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
         hourly_settings = self.bot.setting.get_setting(setting_name='delegate_hourly')
         if hourly_settings["status"] == 1:
+            delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
             if not delegate_stats.get("error"):
                 if hourly_settings["status"] == 1:
                     await self.delegate_overall_message(delegate_settings=hourly_settings,

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -302,13 +302,15 @@ def start_tasks(automatic_tasks):
     scheduler.add_job(automatic_tasks.delegate_hourly_snapshots,
                       CronTrigger(minute='00', second='00'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_3_h,
-                      CronTrigger(hour='00,03,06,09,12,15,18,21', second='2'), misfire_grace_time=2, max_instances=20)
+                      CronTrigger(hour='00,03,06,09,12,15,18,21', minute='00', second='2'), misfire_grace_time=2,
+                      max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_4_h,
-                      CronTrigger(hour='00,04,08,12,16,20', second='2'), misfire_grace_time=2, max_instances=20)
+                      CronTrigger(hour='00,04,08,12,16,20', minute='00', second='2'), misfire_grace_time=2,
+                      max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_6_h,
-                      CronTrigger(hour='06,12,18', second='12'), misfire_grace_time=2, max_instances=20)
+                      CronTrigger(hour='06,12,18', minute='00', second='12'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_12_h,
-                      CronTrigger(hour='00,12', second='10'), misfire_grace_time=2, max_instances=20)
+                      CronTrigger(hour='00,12', minute='00', second='10'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_daily_snapshot,
                       CronTrigger(hour='23', minute='59', second='59'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.system_payment_notifications,

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -122,6 +122,23 @@ class AutomaticTasks:
         else:
             print("Daily snapshots are not included")
 
+    async def delegate_3_h(self):
+        """
+        Send snapshot to channel every 3H
+        """
+        settings = self.bot.setting.get_setting(setting_name='delegate_3h')
+        if settings["status"] == 1:
+            delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
+            if not delegate_stats.get("error"):
+                if settings["status"] == 1:
+                    await self.delegate_overall_message(delegate_settings=settings,
+                                                        delegate_stats=delegate_stats,
+                                                        description='3 H Delegate Snapshot'
+                                                        )
+            else:
+                print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
+        else:
+            print("Daily snapshots are not included")
 
     async def delegate_12_h(self):
         """
@@ -250,6 +267,8 @@ def start_tasks(automatic_tasks):
     print('Started Chron Monitors')
     scheduler.add_job(automatic_tasks.delegate_hourly_snapshots,
                       CronTrigger(minute='00', second='00'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_3_h,
+                      CronTrigger(hour='00,03,06,09,12,15,18,21', second='2'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_12_h,
                       CronTrigger(hour='00,12', second='10'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_daily_snapshot,

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -140,6 +140,26 @@ class AutomaticTasks:
         else:
             print("Daily snapshots are not included")
 
+    async def delegate_4_h(self):
+        """
+        Send snapshot to channel every 4H
+        """
+        settings = self.bot.setting.get_setting(setting_name='delegate_4h')
+        if settings["status"] == 1:
+            delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
+            if not delegate_stats.get("error"):
+                if settings["status"] == 1:
+                    await self.delegate_overall_message(delegate_settings=settings,
+                                                        delegate_stats=delegate_stats,
+                                                        description='4 H Delegate Snapshot'
+                                                        )
+            else:
+                print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
+        else:
+            print("Daily snapshots are not included")
+
+
+
     async def delegate_12_h(self):
         """
         Send snapshot to channel every 12H
@@ -269,6 +289,8 @@ def start_tasks(automatic_tasks):
                       CronTrigger(minute='00', second='00'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_3_h,
                       CronTrigger(hour='00,03,06,09,12,15,18,21', second='2'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_4_h,
+                      CronTrigger(hour='00,04,08,12,16,20', second='2'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_12_h,
                       CronTrigger(hour='00,12', second='10'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_daily_snapshot,

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -1,8 +1,6 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from cogs.utils.customMessages import global_stats, top_delegates
 from xcash_wallet.xcash import XcashManager
-from operator import itemgetter
 from discord import Colour, Embed
 
 from datetime import datetime
@@ -102,7 +100,7 @@ class AutomaticTasks:
             else:
                 print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
         else:
-            print("Daily snapshots are not included")
+            print("Daily snapshots deactivated")
 
     async def delegate_hourly_snapshots(self):
         """
@@ -120,7 +118,7 @@ class AutomaticTasks:
             else:
                 print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
         else:
-            print("Daily snapshots are not included")
+            print("1h snapshot deactivated")
 
     async def delegate_3_h(self):
         """
@@ -138,7 +136,7 @@ class AutomaticTasks:
             else:
                 print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
         else:
-            print("Daily snapshots are not included")
+            print("3h snapshot deactivated")
 
     async def delegate_4_h(self):
         """
@@ -156,7 +154,7 @@ class AutomaticTasks:
             else:
                 print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
         else:
-            print("Daily snapshots are not included")
+            print("4h snapshot deactivated")
 
     async def delegate_6_h(self):
         """
@@ -174,7 +172,7 @@ class AutomaticTasks:
             else:
                 print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
         else:
-            print("Daily snapshots are not included")
+            print("6h snapshot deactivated")
 
     async def delegate_12_h(self):
         """
@@ -192,7 +190,7 @@ class AutomaticTasks:
             else:
                 print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
         else:
-            print("Daily snapshots are not included")
+            print("12h snapshot deactivated")
 
     async def system_payment_notifications(self):
         payment_notifications = self.bot.setting.get_setting(setting_name='payment_notifications')

--- a/AutoTasks.py
+++ b/AutoTasks.py
@@ -122,6 +122,25 @@ class AutomaticTasks:
         else:
             print("Daily snapshots are not included")
 
+
+    async def delegate_12_h(self):
+        """
+        Send snapshot to channel every 12H
+        """
+        settings = self.bot.setting.get_setting(setting_name='delegate_12h')
+        if settings["status"] == 1:
+            delegate_stats = self.dpops_wrapper.delegate_api.get_stats()
+            if not delegate_stats.get("error"):
+                if settings["status"] == 1:
+                    await self.delegate_overall_message(delegate_settings=settings,
+                                                        delegate_stats=delegate_stats,
+                                                        description='12 H Delegate Snapshot'
+                                                        )
+            else:
+                print(f'No API response fr delegate daily snapshot {delegate_stats["error"]}')
+        else:
+            print("Daily snapshots are not included")
+
     async def system_payment_notifications(self):
         payment_notifications = self.bot.setting.get_setting(setting_name='payment_notifications')
         if payment_notifications["status"] == 1:
@@ -229,11 +248,12 @@ def start_tasks(automatic_tasks):
     """
     scheduler = AsyncIOScheduler()
     print('Started Chron Monitors')
-
-    scheduler.add_job(automatic_tasks.delegate_daily_snapshot,
-                      CronTrigger(hour='23', minute='59', second='59'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.delegate_hourly_snapshots,
                       CronTrigger(minute='00', second='00'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_12_h,
+                      CronTrigger(hour='00,12', second='10'), misfire_grace_time=2, max_instances=20)
+    scheduler.add_job(automatic_tasks.delegate_daily_snapshot,
+                      CronTrigger(hour='23', minute='59', second='59'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.system_payment_notifications,
                       CronTrigger(second='05'), misfire_grace_time=2, max_instances=20)
     scheduler.add_job(automatic_tasks.send_payment_dms,

--- a/DiscordBot.py
+++ b/DiscordBot.py
@@ -4,7 +4,7 @@ from discord import Intents
 from utils.tools import Helpers
 
 cogs_to_load = ["cogs.help", 'cogs.autoFunctions', 'cogs.botSetup', "delegate.voterCommands",
-                "cogs.snapshotSetupsDelegate", "cogs.paymentSetupDelegate", "cogs.queriesDelegate"]
+                "cogs.snapshotSetupsDelegate", "cogs.paymentSetupDelegate", "delegate.queriesDelegate"]
 
 
 class DiscordBot(commands.Bot):

--- a/DiscordBot.py
+++ b/DiscordBot.py
@@ -4,7 +4,7 @@ from discord import Intents
 from utils.tools import Helpers
 
 cogs_to_load = ["cogs.help", 'cogs.autoFunctions', 'cogs.botSetup', "delegate.voterCommands",
-                "cogs.snapshotSetupsDelegate", "cogs.paymentSetupDelegate"]
+                "cogs.snapshotSetupsDelegate", "cogs.paymentSetupDelegate", "cogs.queriesDelegate"]
 
 
 class DiscordBot(commands.Bot):

--- a/backendManager/integrityCheck.py
+++ b/backendManager/integrityCheck.py
@@ -3,7 +3,8 @@ class IntegrityCheck(object):
         self.connection = connection
         self.dpops_delegate = self.connection["DpopsDelegate"]  #
         self.required_collections = ["votersDb", "botSettings"]
-        self.required_documents = ["new_block", "delegate_daily", "delegate_hourly", 'payment_notifications']
+        self.required_documents = ["new_block", "delegate_daily", "delegate_hourly",
+                                   "delegate_4h", "delegate_3h", "delegate_6h", "delegate_12h", 'payment_notifications']
 
     def check_collections(self):
         """

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -13,9 +13,12 @@ class HelpCommands(commands.Cog):
         title = ':sos: ___Available Command Categories__ :sos: '
         description = f"Available sub commands for `{self.command_string}help`"
         list_of_commands = [
-            {"name": "Commands for voter",
+            {"name": ":judge: Delegate on-demand",
+             "value": f"```{self.command_string}delegate```\n"
+                      f"`Alias:d`"},
+            {"name": ":ballot_box: Commands for voter",
              "value": f"```{self.command_string}voter```"},
-            {"name": "Commands for server owner",
+            {"name": ":toolbox: Commands for server owner",
              "value": f"```{self.command_string}sys```"},
         ]
         await customMessages.embed_builder(ctx=ctx, c=Colour.green(), title=title, description=description,

--- a/cogs/snapshotSetupsDelegate.py
+++ b/cogs/snapshotSetupsDelegate.py
@@ -17,13 +17,13 @@ class DelegateSnapshotCommands(commands.Cog):
             return 0
 
     async def stats_notifications_manager(self, ctx, setting_name: str, chn: TextChannel, status_code: int,
-                                          status: str):
+                                          status: str,  frame:str):
         if self.bot.setting.update_settings_by_dict(setting_name=setting_name,
                                                     value={"status": int(status_code),
                                                            "channel": int(chn.id)}):
-            await customMessages.system_message(ctx=ctx, c=Colour.green(), title="Hourly Stats Notifications",
-                                                error_details=f"You have successfully set/updated ***Hourly "
-                                                              f"statistic monitor*** every hour on channel"
+            await customMessages.system_message(ctx=ctx, c=Colour.green(), title=f"{frame} Stats Notifications",
+                                                error_details=f"You have successfully set/updated ***{frame} "
+                                                              f"statistic monitor*** on channel"
                                                               f" ***{chn}*** to ***{status.upper()}***",
                                                 destination=ctx.channel)
         else:
@@ -86,7 +86,7 @@ class DelegateSnapshotCommands(commands.Cog):
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
             await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_hourly", chn=chn,
-                                                   status_code=status_code, status=status)
+                                                   status_code=status_code, status=status,frame='1H')
 
 
         else:
@@ -104,7 +104,7 @@ class DelegateSnapshotCommands(commands.Cog):
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
             await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_4h", chn=chn,
-                                                   status_code=status_code, status=status)
+                                                   status_code=status_code, status=status, frame='4H')
         else:
             await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
                                                 error_details=f"You have provided wrong status. Available are"
@@ -120,7 +120,7 @@ class DelegateSnapshotCommands(commands.Cog):
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
             await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_3h", chn=chn,
-                                                   status_code=status_code, status=status)
+                                                   status_code=status_code, status=status, frame='3H')
         else:
             await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
                                                 error_details=f"You have provided wrong status. Available are"
@@ -136,7 +136,7 @@ class DelegateSnapshotCommands(commands.Cog):
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
             await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_6h", chn=chn,
-                                                   status_code=status_code, status=status)
+                                                   status_code=status_code, status=status, frame=f'6H')
         else:
             await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
                                                 error_details=f"You have provided wrong status. Available are"
@@ -152,7 +152,7 @@ class DelegateSnapshotCommands(commands.Cog):
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
             await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_12h", chn=chn,
-                                                   status_code=status_code, status=status)
+                                                   status_code=status_code, status=status, frame=f'12H')
         else:
             await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
                                                 error_details=f"You have provided wrong status. Available are"

--- a/cogs/snapshotSetupsDelegate.py
+++ b/cogs/snapshotSetupsDelegate.py
@@ -16,18 +16,43 @@ class DelegateSnapshotCommands(commands.Cog):
         elif status == 'off':
             return 0
 
+    async def stats_notifications_manager(self, ctx, setting_name: str, chn: TextChannel, status_code: int,
+                                          status: str):
+        if self.bot.setting.update_settings_by_dict(setting_name=setting_name,
+                                                    value={"status": int(status_code),
+                                                           "channel": int(chn.id)}):
+            await customMessages.system_message(ctx=ctx, c=Colour.green(), title="Hourly Stats Notifications",
+                                                error_details=f"You have successfully set/updated ***Hourly "
+                                                              f"statistic monitor*** every hour on channel"
+                                                              f" ***{chn}*** to ***{status.upper()}***",
+                                                destination=ctx.channel)
+        else:
+            await customMessages.system_message(ctx=ctx, c=Colour.red(), title="System Error",
+                                                error_details="It seems like there haas been a backend issue."
+                                                              " Please try again later or open github ticket "
+                                                              "and let us know.",
+                                                destination=ctx.channel)
+
     @commands.group()
     @commands.check(is_public)
     @commands.check(is_owner)
     async def stats(self, ctx):
         if ctx.invoked_subcommand is None:
             title = ':sos: __System Commands :sos: '
-            description = f"Available commands to operate with automatic statistical notifications. "
+            description = f"Available timeframes for Delegate stats snapshots"
             list_of_commands = [
                 {"name": "Daily Stats Notifications",
                  "value": f"```{self.command_string}stats daily <#TextChannel> <on/off>```"},
-                {"name": "Hourly Stats Notifications",
+                {"name": "1H Notifications",
                  "value": f"```{self.command_string}stats hourly <#TextChannel> <on/off>```"},
+                {"name": "3H Stats Notifications",
+                 "value": f"```{self.command_string}stats h3 <#TextChannel> <on/off>```"},
+                {"name": "4H Stats Notifications",
+                 "value": f"```{self.command_string}stats h4 <#TextChannel> <on/off>```"},
+                {"name": "6H Stats Notifications",
+                 "value": f"```{self.command_string}stats h6 <#TextChannel> <on/off>```"},
+                {"name": "12H Stats Notifications",
+                 "value": f"```{self.command_string}stats h12 <#TextChannel> <on/off>```"},
                 {"name": ":warning: Warning ",
                  "value": f"Be sure that the bot has required permissions to view and write to the channel, "
                           f"where stats will be sent. "}
@@ -44,21 +69,8 @@ class DelegateSnapshotCommands(commands.Cog):
         status = status.lower()
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
-
-            if self.bot.setting.update_settings_by_dict(setting_name="delegate_daily",
-                                                        value={"status": int(status_code),
-                                                               "channel": int(chn.id)}):
-                await customMessages.system_message(ctx=ctx, c=Colour.green(), title="Daily Stats Notifications",
-                                                    error_details=f"You have successfully set/updated ***Daily "
-                                                                  f"statistic monitor*** for delegate @ 23:59:59 every"
-                                                                  f" day on ***{chn}*** to ***{status.upper()}***",
-                                                    destination=ctx.channel)
-            else:
-                await customMessages.system_message(ctx=ctx, c=Colour.red(), title="System Error",
-                                                    error_details="It seems like there haas been a backend issue."
-                                                                  " Please try again later or open github ticket "
-                                                                  "and let us know.",
-                                                    destination=ctx.channel)
+            await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_daily", chn=chn,
+                                                   status_code=status_code, status=status)
         else:
             await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
                                                 error_details=f"You have provided wrong status. Available are"
@@ -68,25 +80,79 @@ class DelegateSnapshotCommands(commands.Cog):
     @stats.command()
     async def hourly(self, ctx, chn: TextChannel, status: str):
         """
-        Operate with hourly operations
+        Hourly setup
         """
         status = status.lower()
         if status and status in ["on", "off"]:
             status_code = self.get_status_number(status=status)
-            if self.bot.setting.update_settings_by_dict(setting_name="delegate_hourly",
-                                                        value={"status": int(status_code),
-                                                               "channel": int(chn.id)}):
-                await customMessages.system_message(ctx=ctx, c=Colour.green(), title="Hourly Stats Notifications",
-                                                    error_details=f"You have successfully set/updated ***Hourly "
-                                                                  f"statistic monitor*** every hour on channel"
-                                                                  f" ***{chn}*** to ***{status.upper()}***",
-                                                    destination=ctx.channel)
-            else:
-                await customMessages.system_message(ctx=ctx, c=Colour.red(), title="System Error",
-                                                    error_details="It seems like there haas been a backend issue."
-                                                                  " Please try again later or open github ticket "
-                                                                  "and let us know.",
-                                                    destination=ctx.channel)
+            await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_hourly", chn=chn,
+                                                   status_code=status_code, status=status)
+
+
+        else:
+            await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
+                                                error_details=f"You have provided wrong status. Available are"
+                                                              f" ***on/off*** while yours was {status}",
+                                                destination=ctx.channel)
+
+    @stats.command()
+    async def h4(self, ctx, chn: TextChannel, status: str):
+        """
+        every 4h setup
+        """
+        status = status.lower()
+        if status and status in ["on", "off"]:
+            status_code = self.get_status_number(status=status)
+            await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_4h", chn=chn,
+                                                   status_code=status_code, status=status)
+        else:
+            await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
+                                                error_details=f"You have provided wrong status. Available are"
+                                                              f" ***on/off*** while yours was {status}",
+                                                destination=ctx.channel)
+
+    @stats.command()
+    async def h3(self, ctx, chn: TextChannel, status: str):
+        """
+        every 3h setup
+        """
+        status = status.lower()
+        if status and status in ["on", "off"]:
+            status_code = self.get_status_number(status=status)
+            await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_3h", chn=chn,
+                                                   status_code=status_code, status=status)
+        else:
+            await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
+                                                error_details=f"You have provided wrong status. Available are"
+                                                              f" ***on/off*** while yours was {status}",
+                                                destination=ctx.channel)
+
+    @stats.command()
+    async def h6(self, ctx, chn: TextChannel, status: str):
+        """
+        every 6h setup
+        """
+        status = status.lower()
+        if status and status in ["on", "off"]:
+            status_code = self.get_status_number(status=status)
+            await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_6h", chn=chn,
+                                                   status_code=status_code, status=status)
+        else:
+            await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
+                                                error_details=f"You have provided wrong status. Available are"
+                                                              f" ***on/off*** while yours was {status}",
+                                                destination=ctx.channel)
+
+    @stats.command()
+    async def h12(self, ctx, chn: TextChannel, status: str):
+        """
+        every 12h setup
+        """
+        status = status.lower()
+        if status and status in ["on", "off"]:
+            status_code = self.get_status_number(status=status)
+            await self.stats_notifications_manager(ctx=ctx, setting_name="delegate_12h", chn=chn,
+                                                   status_code=status_code, status=status)
         else:
             await customMessages.system_message(ctx=ctx, c=Colour.red(), title="Wrong Status",
                                                 error_details=f"You have provided wrong status. Available are"

--- a/delegate/queriesDelegate.py
+++ b/delegate/queriesDelegate.py
@@ -1,0 +1,32 @@
+from discord.ext import commands
+from delegate.tools.customMessages import delegate_stats, embed_builder
+from discord import Colour
+
+
+class DelegateQueries(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.command_string = self.bot.get_command_str()
+
+    @commands.group(aliases=['d'])
+    async def delegate(self, ctx):
+        if ctx.invoked_subcommand is None:
+            title = ':judge: Delegate Informational Commands'
+            description = f"Informational commands on the delegate"
+            list_of_commands = [
+                {"name": ":chart_with_upwards_trend: Stats on-demand",
+                 "value": f"```{self.command_string}delegate stats```\n"
+                          f"`Aliases: s`"}
+            ]
+            await embed_builder(ctx=ctx, c=Colour.green(), title=title, description=description,
+                                data=list_of_commands)
+
+    @delegate.command(aliases=["s"])
+    async def stats(self, ctx):
+        stats = self.bot.dpops_queries.delegate_api.get_stats()
+
+        await delegate_stats(destination=ctx.author, data=stats, thumbnail=self.bot.user.avatar_url)
+
+
+def setup(bot):
+    bot.add_cog(DelegateQueries(bot))

--- a/delegate/tools/customMessages.py
+++ b/delegate/tools/customMessages.py
@@ -41,27 +41,27 @@ async def delegate_stats(destination, data: dict, thumbnail):
              'total_xcash_from_blocks_found': '2472432078918'}
      """
     data_embed = Embed(title=f'{data["delegate_name"]} Stats',
-                       description=f"Current statistics about X-Payment-World delegate operating on {data['fee']}% fee"
-                                   f" and minimum payment amount {data['minimum_amount']} XCASH.",
+                       description=f"Current statistics about X-Payment-World delegate operating on ***{round(float(data['fee']), 2)}%*** fee"
+                                   f" and minimum payment amount ***{int(data['minimum_amount']):,}*** XCASH.",
                        colour=Colour.green(),
                        timestamp=datetime.utcnow())
     data_embed.set_thumbnail(url=thumbnail)
     data_embed.add_field(name=f':first_place: Rank',
-                         value=f'`{data["current_delegate_rank"]}`')
-    data_embed.add_field(name=f':timer: Online',
-                         value=f'`{data["online_percentage"]}%`')
-    data_embed.add_field(name=f':bricks: Blocks Found',
-                         value=f'`{data["total_blocks_found"]}`')
-    data_embed.add_field(name=f':judge: Rounds Verifier',
-                         value=f'`{data["block_verifier_total_rounds"]}`')
-    data_embed.add_field(name=f':pick: XCASH Mined',
-                         value=f'`{int(float(data["total_xcash_from_blocks_found"]) / (10 ** 6)):,} XCASH`')
-    data_embed.add_field(name=f':incoming_envelope: Total Payments',
-                         value=f'`{data["total_payments"]}`')
+                         value=f'```{data["current_delegate_rank"]}```')
+    data_embed.add_field(name=f':timer: Online Percentage',
+                         value=f'```{data["online_percentage"]}%```')
     data_embed.add_field(name=f':cowboy: Total Voters',
-                         value=f'`{data["total_voters"]}`')
-    data_embed.add_field(name=f':envelope_with_arrow: Total Votes',
-                         value=f'`{int(float(data["total_votes"]) / (10 ** 7)):,} XCASH`')
+                         value=f'```{data["total_voters"]}```')
+    data_embed.add_field(name=f':ballot_box: Total Votes',
+                         value=f'```{int(float(data["total_votes"]) / (10 ** 7)):,} XCASH```')
+    data_embed.add_field(name=f':pick: Total XCASH',
+                         value=f'```{int(float(data["total_xcash_from_blocks_found"]) / (10 ** 6)):,} XCASH```')
+    data_embed.add_field(name=f':incoming_envelope: Total Payments',
+                         value=f'```{data["total_payments"]}```')
+    data_embed.add_field(name=f':bricks: Blocks Found',
+                         value=f'```{data["total_blocks_found"]}```')
+    data_embed.add_field(name=f':judge: Blocks Verified',
+                         value=f'```{data["block_verifier_total_rounds"]}```')
     await destination.send(embed=data_embed)
 
 
@@ -109,14 +109,13 @@ async def state_info(ctx, data: dict, xcash_price_usdt: dict):
             penny = xcash_price_usdt["USD"]
             usd_final = round((micro * penny), 4)
             total_payed = int(data["total"]) / (10 ** 7)
-            total_usd_payed_final = round(total_payed * penny,4)
+            total_usd_payed_final = round(total_payed * penny, 4)
         except ZeroDivisionError:
             usd_final = 0.00
             total_usd_payed_final = 0.00
 
     state_nfo.add_field(name=':hourglass_flowing_sand: Current Pending',
                         value=f':coin: `{current_pending:,} XCASH` \n:flag_us: `${usd_final}`')
-
 
     state_nfo.add_field(name=':moneybag: Total Payed ',
                         value=f':coin: `{round(int(data["total"]) / (10 ** 7), 6)}XCASH`\n'


### PR DESCRIPTION
New timeframes to apply for delegate stats dispatcher:
3h,4h,6h,12h

New category of commands:
!delegate --> Open for all 

sub-command integrated:
!delegate stats --> Returns current delegate stats from DPOPS system  on-demand